### PR TITLE
Update to Node.js version 5.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk --update add --virtual build-dependencies \
     paxctl \
     libgcc \
     libstdc++ && \
-    curl -s https://nodejs.org/dist/${NODEJS_VERSION}/node-${NODEJS_VERSION}.tar.gz | tar -xz && \
+    curl -s -S https://nodejs.org/dist/${NODEJS_VERSION}/node-${NODEJS_VERSION}.tar.gz | tar -xz && \
     cd /node-${NODEJS_VERSION} && \
     ./configure --prefix=/usr && \
     make -j$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.2
 
-ENV NODEJS_VERSION=v5.12
+ENV NODEJS_VERSION=v5.12.0
 ENV DEL_PKGS="libgcc libstdc++" RM_DIRS=/usr/include
 
 RUN apk --update add --virtual build-dependencies \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.2
 
-ENV NODEJS_VERSION=v5.2.0
+ENV NODEJS_VERSION=v5.12
 ENV DEL_PKGS="libgcc libstdc++" RM_DIRS=/usr/include
 
 RUN apk --update add --virtual build-dependencies \


### PR DESCRIPTION
* Use Node.js version 5.12.0
* Show errors even when output is silenced